### PR TITLE
Updates alpine images

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Build Stage
-FROM golang:1.13-alpine AS build-stage
+FROM golang:1.14-alpine AS build-stage
 
 LABEL app="build-oidc-ingress"
 LABEL REPO="https://github.com/pwillie/oidc-ingress"
@@ -11,7 +11,7 @@ ENV GOROOT=/usr/local/go \
 
 RUN apk add -U -q --no-progress build-base git
 RUN wget -q https://github.com/golang/dep/releases/download/v0.3.2/dep-linux-amd64 -O /usr/local/bin/dep \
- && chmod +x /usr/local/bin/dep
+    && chmod +x /usr/local/bin/dep
 
 # Because of https://github.com/docker/docker/issues/14914
 ENV PATH=$PATH:$GOROOT/bin:$GOPATH/bin
@@ -22,7 +22,7 @@ ADD . /gopath/src/github.com/pwillie/oidc-ingress
 RUN make get-deps && make build-alpine
 
 # Final Stage (pwillie/oidc-ingress)
-FROM alpine:3.8
+FROM alpine:3.11
 
 ARG GIT_COMMIT
 ARG VERSION


### PR DESCRIPTION
Updates golang alpine to 1.14.
Updates base binary image to alpine 3.11

Required for DEVOPS-392