### PR TITLE
SECOPS-46: Add SameSite=Strict to Set-Cookie header

### DIFF
--- a/pkg/handlers/oidc.go
+++ b/pkg/handlers/oidc.go
@@ -402,10 +402,11 @@ func (o Oidc) CallbackHandler(w http.ResponseWriter, r *http.Request) {
 	}
 
 	cookie := http.Cookie{
-		Name:   config.Name,
-		Path:   "/",
-		Domain: config.CookieDomain,
-		Value:  encoded,
+		Name:     config.Name,
++               Path:     "/",
++               Domain:   config.CookieDomain,
++               Value:    encoded,
++               SameSite: 3,
 	}
 	http.SetCookie(w, &cookie)
 	o.logger.WithFields(logrus.Fields{

--- a/pkg/handlers/oidc.go
+++ b/pkg/handlers/oidc.go
@@ -403,10 +403,10 @@ func (o Oidc) CallbackHandler(w http.ResponseWriter, r *http.Request) {
 
 	cookie := http.Cookie{
 		Name:     config.Name,
-+               Path:     "/",
-+               Domain:   config.CookieDomain,
-+               Value:    encoded,
-+               SameSite: 3,
+                Path:     "/",
+                Domain:   config.CookieDomain,
+                Value:    encoded,
+                SameSite: 3,
 	}
 	http.SetCookie(w, &cookie)
 	o.logger.WithFields(logrus.Fields{

--- a/pkg/handlers/oidc_test.go
+++ b/pkg/handlers/oidc_test.go
@@ -355,6 +355,7 @@ func TestCallbackOKRedirects(t *testing.T) {
 	defer resp.Body.Close()
 
 	assert.Equal(t, 302, resp.StatusCode)
+	assert.True(t, strings.Contains(resp.Header["Set-Cookie"][0], "SameSite=Strict"))
 	assert.Equal(t, 1, len(resp.Cookies()))
 	location, _ := resp.Location()
 	assert.Equal(t, "https://horton.hoo.com", location.String())


### PR DESCRIPTION
The Same-Site cookie directive was incorporated in the leading desktop browsers in early 2020. Its purpose is to prevent common types of Cross Site Request Forgery (CSRF) attack. This protective measure is added to the “Set-Cookie” header sent by web servers and comes with three different configuration options:

-None
-Lax
-Strict

To prevent common types of CSRF, the "Strict" type should be set for the cookie generated on the auth redirect.

This MR does that
