### PR TITLE
SECOPS-46: Perform Client Side redirect

### DIFF
--- a/pkg/handlers/oidc.go
+++ b/pkg/handlers/oidc.go
@@ -54,7 +54,7 @@ const clientSideRedirectPage = `
 <body> 
 <p>Redirecting...</p> 
 </body>  
-</html>"`
+</html>`
 
 // NewOidcHandler creates a new object for handling all oidc authorisation requests.
 func NewOidcHandler(config string, externalURL string, stateStorer StateStorer, logger *logrus.Logger) (*Oidc, error) {

--- a/pkg/handlers/oidc.go
+++ b/pkg/handlers/oidc.go
@@ -417,6 +417,7 @@ func (o Oidc) CallbackHandler(w http.ResponseWriter, r *http.Request) {
                 Domain:   config.CookieDomain,
                 Value:    encoded,
                 SameSite: 3,
+				Secure:   true,
 	}
 	http.SetCookie(w, &cookie)
 	o.logger.WithFields(logrus.Fields{

--- a/pkg/handlers/oidc.go
+++ b/pkg/handlers/oidc.go
@@ -45,6 +45,16 @@ type StateStorer interface {
 }
 
 const cookieName = "jwt"
+const clientSideRedirectPage = `
+<html xmlns="http://www.w3.org/1999/xhtml">    
+<head>      
+<title>Redirecting</title>      
+<meta http-equiv="refresh" content="0;URL='%v'" />    
+</head>    
+<body> 
+<p>Redirecting...</p> 
+</body>  
+</html>"`
 
 // NewOidcHandler creates a new object for handling all oidc authorisation requests.
 func NewOidcHandler(config string, externalURL string, stateStorer StateStorer, logger *logrus.Logger) (*Oidc, error) {
@@ -415,10 +425,10 @@ func (o Oidc) CallbackHandler(w http.ResponseWriter, r *http.Request) {
 		"cookie":  cookie,
 	}).Debug("Cookie set - redirecting back to application.")
 
+	w.Header().Set("Content-Type", "text/html; charset=utf-8")
 	if r.URL.Query().Get("rd") != "" {
-		http.Redirect(w, r, r.URL.Query().Get("rd"), http.StatusFound)
+		fmt.Fprintf(w, clientSideRedirectPage, r.URL.Query().Get("rd"))
 		return
 	}
-	http.Redirect(w, r, redirectURL, http.StatusFound)
-	return
+	fmt.Fprintf(w, clientSideRedirectPage, redirectURL)
 }

--- a/pkg/handlers/oidc_test.go
+++ b/pkg/handlers/oidc_test.go
@@ -354,9 +354,9 @@ func TestCallbackOKRedirects(t *testing.T) {
 	resp := rr.Result()
 	defer resp.Body.Close()
 
-	assert.Equal(t, 302, resp.StatusCode)
+	assert.Equal(t, 200, resp.StatusCode)
 	assert.True(t, strings.Contains(resp.Header["Set-Cookie"][0], "SameSite=Strict"))
 	assert.Equal(t, 1, len(resp.Cookies()))
-	location, _ := resp.Location()
-	assert.Equal(t, "https://horton.hoo.com", location.String())
+	assert.Equal(t, rr.Body.String(), "\n<html xmlns=\"http://www.w3.org/1999/xhtml\">    \n<head>      \n<title>Redirecting</title>      \n<meta http-equiv=\"refresh\" content=\"0;URL='https://horton.hoo.com'\" />    \n</head>    \n<body> \n<p>Redirecting...</p> \n</body>  \n</html>\"")
+
 }

--- a/pkg/handlers/oidc_test.go
+++ b/pkg/handlers/oidc_test.go
@@ -357,6 +357,6 @@ func TestCallbackOKRedirects(t *testing.T) {
 	assert.Equal(t, 200, resp.StatusCode)
 	assert.True(t, strings.Contains(resp.Header["Set-Cookie"][0], "SameSite=Strict"))
 	assert.Equal(t, 1, len(resp.Cookies()))
-	assert.Equal(t, rr.Body.String(), "\n<html xmlns=\"http://www.w3.org/1999/xhtml\">    \n<head>      \n<title>Redirecting</title>      \n<meta http-equiv=\"refresh\" content=\"0;URL='https://horton.hoo.com'\" />    \n</head>    \n<body> \n<p>Redirecting...</p> \n</body>  \n</html>\"")
+	assert.Equal(t, rr.Body.String(), "\n<html xmlns=\"http://www.w3.org/1999/xhtml\">    \n<head>      \n<title>Redirecting</title>      \n<meta http-equiv=\"refresh\" content=\"0;URL='https://horton.hoo.com'\" />    \n</head>    \n<body> \n<p>Redirecting...</p> \n</body>  \n</html>")
 
 }

--- a/pkg/handlers/oidc_test.go
+++ b/pkg/handlers/oidc_test.go
@@ -356,6 +356,7 @@ func TestCallbackOKRedirects(t *testing.T) {
 
 	assert.Equal(t, 200, resp.StatusCode)
 	assert.True(t, strings.Contains(resp.Header["Set-Cookie"][0], "SameSite=Strict"))
+	assert.True(t, strings.Contains(resp.Header["Set-Cookie"][0], "Secure"))
 	assert.Equal(t, 1, len(resp.Cookies()))
 	assert.Equal(t, rr.Body.String(), "\n<html xmlns=\"http://www.w3.org/1999/xhtml\">    \n<head>      \n<title>Redirecting</title>      \n<meta http-equiv=\"refresh\" content=\"0;URL='https://horton.hoo.com'\" />    \n</head>    \n<body> \n<p>Redirecting...</p> \n</body>  \n</html>")
 


### PR DESCRIPTION
This change will perform a client side redirect to the desired page (using the HTML "Meta" tag).

This allows us the perform the redirect just as before but without downgrading the cookie to "SameSite=Lax".Without this change, most major browsers would end up in a redirect loop and eventually return an error "Too Many Redirects" - This is because of the way they handle cookies with SameSite=Strict.

Detail on this issue: https://community.nintex.com/t5/Technical-Issues/Known-Issue-Behavioral-change-in-web-browsers-for-handling/ta-p/125985

To the end user, the experience is the same. In the backend, the last response from the oidc container will no longer be a 302 redirect. Instead it will be a 200 with body:

```<html xmlns="http://www.w3.org/1999/xhtml">    
<head>      
<title>Redirecting</title>      
<meta http-equiv="refresh" content="0;URL='https://The Url To Redirect/to/Here'" />    
</head>    
<body> 
<p>Redirecting...</p> 
</body>  
</html>