### PR TITLE
Updated elgohr/Publish-Docker-Github-Action to a supported version (v5)

### DIFF
--- a/.github/workflows/release-build.yml
+++ b/.github/workflows/release-build.yml
@@ -45,7 +45,7 @@ jobs:
           asset_path: ${{ github.workspace }}/artifacts/binaries/uav-windows-amd64.exe
 
       - name: Publish to Dockerhub
-        uses: elgohr/Publish-Docker-Github-Action@2.21
+        uses: elgohr/Publish-Docker-Github-Action@v5
         with:
           name: finbourne/oidc-ingress
           username: ${{ secrets.DOCKERHUB_USERNAME }}


### PR DESCRIPTION
elgohr/Publish-Docker-Github-Action@master is not supported anymore