### PR TITLE
Remove static externalURL, implement dynamic per-request callback host; modernize build image; add dynamic callback tests

### DIFF
--- a/cmd/oidc-ingress/main.go
+++ b/cmd/oidc-ingress/main.go
@@ -28,7 +28,6 @@ type Options struct {
 	InternalAddress    string
 	StateStorage       string
 	StateRemoteAddress string
-	ExternalURL        string
 	VersionFlag        bool
 	Debug              bool
 }
@@ -42,7 +41,6 @@ func init() {
 	flag.StringVar(&options.ListenAddress, "listen", ":8000", "Listen address")
 	flag.StringVar(&options.InternalAddress, "internal", ":9000", "Internal listen address")
 	flag.StringVar(&options.StateRemoteAddress, "redis", "", "The address of the storage cluster.")
-	flag.StringVar(&options.ExternalURL, "externalUrl", "", "The url that the auth service is being served on.")
 	flag.BoolVar(&options.VersionFlag, "version", false, "Version")
 	flag.BoolVar(&options.Debug, "debug", false, "Turn on debug logging.")
 }
@@ -83,7 +81,7 @@ func StartServer(logger *logrus.Logger, options Options) {
 	r := handlers.NewRouter(logger)
 
 	stateStorer := handlers.NewRedisStateStorer(strings.TrimSpace(options.StateRemoteAddress), logger)
-	oidc, err := handlers.NewOidcHandler(options.ClientConfigs, strings.TrimSpace(options.ExternalURL), stateStorer, logger)
+	oidc, err := handlers.NewOidcHandler(options.ClientConfigs, stateStorer, logger)
 	if err != nil {
 		logger.WithError(err).Fatal("Failed to initialise OIDC handler")
 	}

--- a/mise.toml
+++ b/mise.toml
@@ -1,0 +1,2 @@
+[tools]
+go = "latest"


### PR DESCRIPTION
Summary
This merge removes the static externalUrl concept and derives the OIDC redirect (callback) URL dynamically from each incoming request (scheme + host). It modernizes the Docker build, updates tests, and introduces coverage for the new dynamic behavior.

Key Changes
- OIDC handler:
  - Removed externalURL field and constructor parameter.
  - Added baseURL(r) method deriving scheme/host from X-Forwarded-Proto / X-Forwarded-Host (first value) or fallback to request TLS/Host.
  - Updated SigninHandler and CallbackHandler to build callback URL dynamically.
  - Removed legacy external URL logic; any provided external URL now unsupported (hard break).
- Constructor signature change:
  - NewOidcHandler(config string, stateStorer StateStorer, logger *logrus.Logger).
  - Updated all call sites (main.go and tests).
- Tests:
  - Adjusted existing tests for new constructor.
  - Added three new tests:
    - TestSigninDynamicCallbackUsesRequestHost
    - TestSigninDynamicCallbackUsesForwardedHeaders
    - TestSigninDynamicCallbackFallsBackToHTTP
- Dockerfile:
  - Upgraded to Go 1.22 alpine builder.
  - Removed deprecated dep tooling.
  - Added module & build cache mounts.
  - Static binary build with -trimpath and ldflags (GitCommit / VersionPrerelease).
  - Switched runtime to distroless (Debian 12 nonroot).
  - Added OCI metadata labels.
  - Removed legacy user/group creation steps (distroless nonroot used).
- Misc:
  - Removed unused externalURL usage in tests.
  - Left a note in code about removed externalURL support.

Rationale
- Supports multi‑subdomain deployments (per original requirement).
- Avoids hardcoding environment-specific base URL.
- Reduces image size and attack surface (distroless).
- Improves test clarity around redirect behavior.

Breaking Changes
- externalUrl flag/argument no longer honored (constructor signature changed).
- Any automation supplying --externalUrl must be updated/removed.
- Redirect URIs registered with the IdP must now cover each subdomain (wildcard or enumerated).

Security / Behavior Notes
- Trust boundary now depends on X-Forwarded-* headers; must ensure requests always traverse a trusted reverse proxy that normalizes these headers.
- Current implementation does not yet validate forwarded host against an allowlist (follow-up recommended).
- Same cookie semantics retained (improvement suggestions in follow-up section).

Testing Performed
- go test - existing suite adjusted passes (including new dynamic tests).
- Verified redirect_uri in Location header matches:
  - Request host (HTTPS)
  - Forwarded headers overriding host/scheme
  - HTTP fallback when no TLS / forwarded headers
- Callback and sign-in regression tests unchanged.

Migration Steps
1. Remove any use of --externalUrl (deployment manifests / Helm values / env vars).
2. Ensure ingress / proxy sets X-Forwarded-Proto and X-Forwarded-Host correctly.
3. Confirm IdP has redirect URIs for each required subdomain (e.g. https://foo.example.com/auth/callback).
4. Rebuild & deploy with new image (distroless base may require updated security policies / allowlisting).

Follow-Up Recommendations (Not implemented here)
- Validate derived host against configured parent domain / explicit allowlist.
- Add nonce & (optional) PKCE to OIDC flow.
- Harden cookie (HttpOnly, explicit SameSite constant, optional encryption block key).
- Replace global test function overrides with interfaces (dependency injection).
- Precompile AllowedRedirects regexes and anchor them.
- Add metrics counters (signin attempts, failures, callback errors).
- Introduce lint/security tooling (golangci-lint, gosec).
- Upgrade redis client to v9 and use contexts with timeouts.

Rollback Plan
- Revert to previous commit and restore externalUrl usage.
- Redeploy old image; IdP redirect registrations remain compatible.

Checklist
- [x] Code compiles
- [x] Tests updated and passing
- [x] Breaking change documented
- [x] Docker image builds locally
- [ ] (Pending) README / deployment docs update

Let me know if you want a README update or follow-up PR template.